### PR TITLE
fixed IndexBuffer type(16bit -> 32 bit) for DX11 port

### DIFF
--- a/example/example_d3d11.c
+++ b/example/example_d3d11.c
@@ -440,7 +440,9 @@ BOOL InitializeDX(unsigned int x, unsigned int y)
     }
     if (SUCCEEDED(hr))
     {
+#ifdef DEMO_MSAA
         UINT i;
+#endif
         ZeroMemory(&swapDesc, sizeof(swapDesc));
 
         swapDesc.SampleDesc.Count = 1;        //The Number of Multisamples per Level
@@ -462,8 +464,6 @@ BOOL InitializeDX(unsigned int x, unsigned int y)
                 }
             }
         }
-#else
-        NVG_NOTUSED(i);
 #endif
 
         swapDesc.BufferDesc.Width = x;

--- a/src/nanovg_d3d11.h
+++ b/src/nanovg_d3d11.h
@@ -327,21 +327,21 @@ static void D3Dnvg__deleteShader(struct D3DNVGshader* shader)
 
 void D3Dnvg_buildFanIndices(struct D3DNVGcontext* D3D)
 {
-    D3D11_MAPPED_SUBRESOURCE resource;
-    WORD* pIndices;
-    unsigned int index0 = 0;
-    unsigned int index1 = 1;
-    unsigned int index2 = 2;
-    unsigned int current = 0;
+    UINT32 index0 = 0;
+    UINT32 index1 = 1;
+    UINT32 index2 = 2;
+    UINT32 current = 0;
+	D3D11_MAPPED_SUBRESOURCE resource;
+	UINT32* pIndices = NULL;
 
     D3D_API_5(D3D->pDeviceContext, Map, (ID3D11Resource*)D3D->pFanIndexBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
-    pIndices = (WORD*)resource.pData;
+    pIndices = (UINT32*)resource.pData;
     
     while (current < (D3D->VertexBuffer.MaxBufferEntries - 3))
     {
-        pIndices[current++] = (WORD)index0;
-        pIndices[current++] = (WORD)index1++;
-        pIndices[current++] = (WORD)index2++;
+        pIndices[current++] = index0;
+        pIndices[current++] = index1++;
+        pIndices[current++] = index2++;
     }
     D3D_API_2(D3D->pDeviceContext, Unmap, (ID3D11Resource*)D3D->pFanIndexBuffer, 0);
 }
@@ -424,7 +424,7 @@ static void D3Dnvg_setBuffers(struct D3DNVGcontext* D3D, unsigned int dynamicOff
     strides[0] = sizeof(struct NVGvertex);
     offsets[0] = dynamicOffset * sizeof(struct NVGvertex);
 
-    D3D_API_3(D3D->pDeviceContext, IASetIndexBuffer, D3D->pFanIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
+    D3D_API_3(D3D->pDeviceContext, IASetIndexBuffer, D3D->pFanIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
     D3D_API_5(D3D->pDeviceContext, IASetVertexBuffers, 0, 1, pBuffers, strides, offsets);
     D3D_API_1(D3D->pDeviceContext, IASetInputLayout, D3D->pLayoutRenderTriangles);
 }
@@ -480,7 +480,7 @@ static int D3Dnvg__renderCreate(void* uptr)
     D3Dnvg__checkError(hr, "Create Vertex Buffer");
 
     bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
-    bufferDesc.ByteWidth = sizeof(WORD)* D3D->VertexBuffer.MaxBufferEntries;
+    bufferDesc.ByteWidth = sizeof(UINT32)* D3D->VertexBuffer.MaxBufferEntries;
     hr = D3D_API_3(D3D->pDevice, CreateBuffer, &bufferDesc, NULL, &D3D->pFanIndexBuffer);
     D3Dnvg__checkError(hr, "Create Vertex Buffer Static");
 


### PR DESCRIPTION
Now works fine! Orig. version leads to DX debug guards.
Btw: NICE work! it works faster and with less CPU load then GL version!
